### PR TITLE
Update AstroNvim Configuration Source

### DIFF
--- a/neovim_distros
+++ b/neovim_distros
@@ -7,7 +7,7 @@
 # alias      | Github repository       | default or branch name
 readonly neovim_distros=(
   "default    | none                    | none"
-  "astro      | AstroNvim/AstroNvim     | default"
+  "astro      | AstroNvim/template      | default"
   "asyncedd   | asyncedd/dots.nvim      | default"
   "barebones  | Traap/barebones         | default"
   "barelazy   | Traap/barebones         | lazy"


### PR DESCRIPTION
Issue:

```This repository is not meant to be used as a direct Neovim configuration```
<img width="573" alt="image" src="https://github.com/user-attachments/assets/01cce3cb-7072-4aa9-9e1d-14041eb1d75d">

Change:
The old repository (https://github.com/AstroNvim/AstroNvim) is no longer in use for configuration purposes. The new repository (https://github.com/AstroNvim/template) will now be used for starting the AstroNvim configuration.